### PR TITLE
Fix package version in setup.py

### DIFF
--- a/benchmark/dockerfile_template
+++ b/benchmark/dockerfile_template
@@ -39,5 +39,4 @@ COPY . ${SMORT}
 
 RUN cd ${SMORT} && \
     pip3 install -U pip && \
-    pip install more_itertools && \
     pip install -r dev_requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 from setuptools import setup
-from smort_query import __version__
+
+with open("smort_query/__init__.py", "r") as f:
+    lines = f.readlines()
+    ver = filter(lambda l: l.startswith("__version__"), lines)
+    __version__ = next(ver).split("=")[-1].strip().strip('"')
 
 with open("README.md") as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
In PR #75 I proposed to move version label to `__init__.py` of the main package instead of keeping it in `setup.py`. Therefore `__version__` was imported from `smort_query` package before calling `setup()` function. `setup()` function contains dependencies like `install_requires=["more_itertools~=8.0"]`. Importing something from `smort_query` package before calling `setup()` throws an exception that `more_itertools` package is not installed.

This bug interrupts CI/CD building process of the package. The solution is to read a content of the `__init__.py` with the usage of `open()` function. Check also [single-sourcing-package-version](https://packaging.python.org/en/latest/guides/single-sourcing-package-version).