### PR TITLE
Adjust benchmark code to checkers

### DIFF
--- a/benchmark/benchmark_cli.py
+++ b/benchmark/benchmark_cli.py
@@ -6,7 +6,7 @@ from argparse import ArgumentParser, RawTextHelpFormatter
 from pathlib import Path
 from textwrap import dedent
 
-import matplotlib.pyplot as plt
+import matplotlib.pyplot as plt  # type: ignore
 
 from benchmark import project_name
 from benchmark.testlib import (
@@ -22,7 +22,7 @@ from benchmark.testlib import (
 arg_parser = ArgumentParser(
     prog=f"python3 {Path(__file__).name}",
     description=f"Make benchmark tests for {project_name.replace(' ', '_')} package",
-    epilog=f"v0.1.0, python {python_ver}",
+    epilog=f"v0.1.1, python {python_ver}",
     formatter_class=RawTextHelpFormatter,
 )
 
@@ -118,9 +118,8 @@ if args.show or (args.img is not None):
         ObjectQuery=oq_performance,
         DataFrame=df_performance,
     )
-
-if args.img is not None:
-    fig.savefig(args.img, bbox_inches="tight", pad_inches=0.2, dpi=120)
+    if args.img is not None:
+        fig.savefig(args.img, bbox_inches="tight", pad_inches=0.2, dpi=120)
 
 if args.show:
     plt.show()

--- a/benchmark/testlib.py
+++ b/benchmark/testlib.py
@@ -20,7 +20,7 @@ from textwrap import dedent
 from timeit import repeat
 from typing import Callable, List
 
-import matplotlib.pyplot as plt
+import matplotlib.pyplot as plt  # type: ignore
 from pandas import DataFrame
 from pandas import __version__ as pd_ver
 from smort_query import ObjectQuery
@@ -90,7 +90,10 @@ def execute_data_frame() -> str:
 
 
 def test_filtering(number: int, setup: Callable, execute_code: Callable) -> float:
-    """Test efficiency of filtering by different objects for a given number of items to filter."""
+    """
+    Test efficiency of filtering by different objects for a given number of items
+    to filter.
+    """
     setup_code = setup(number)
     test_code = execute_code()
     time_execution = repeat(
@@ -115,7 +118,10 @@ def tested_version() -> str:
 def plot_results(
     size: list, title: str, version: str, **kwargs: List[float]
 ) -> plt.Figure:
-    """Plot comparison of time execution for two different objects with variable size of input data."""
+    """
+    Plot comparison of time execution for two different objects with variable
+    size of input data.
+    """
     colors = ("blue", "orange")
 
     fig, ax = plt.subplots()

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -8,6 +8,7 @@ pytest==7.1.2
 pytest-cov==3.0.0
 twine==4.0.1
 wheel==0.37.1
-matplotlib==3.5.2
+matplotlib==3.5.3
 mypy==0.971
 pandas==1.4.3
+pandas-stubs~=1.4.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,8 @@
 [flake8]
 ignore = BLK100,E231,W503,D102,D103
+per-file-ignores = testlib.py:F401
 max-line-length = 88
-exclude = 
+exclude =
     .git,
     __pycache__,
     docs/source/conf.py,


### PR DESCRIPTION
Benchmark code from PR #75 wasn't adapted to git hook checkers and some of them failed. I tested them locally and fixed. Please, note that `matplotlib` doesn't contain stubs so must be ignored by `mypy`. `flake8` reports that some import statements are unused. It's not true because they are used by the `globals()` in `repeat` function. This PR also fixes #32 issue.